### PR TITLE
Fix inquirer import in setup script

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const inquirer = require('inquirer');
+// Inquirer v9 is ESM-only. Using `.default` ensures we access the
+// actual inquirer module with the `prompt` method when importing via
+// CommonJS `require`.
+const inquirer = require('inquirer').default;
 
 const configPath = path.join(__dirname, 'config.json');
 


### PR DESCRIPTION
## Summary
- fix setup script to import inquirer default export so prompt function exists

## Testing
- `node setup.js`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689b269322108327a5db766a6ebd1309